### PR TITLE
Add Google OAuth controller

### DIFF
--- a/app/Http/Controllers/Auth/GoogleController.php
+++ b/app/Http/Controllers/Auth/GoogleController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Services\GoogleCalendarService;
+use Illuminate\Http\Request;
+
+class GoogleController extends Controller
+{
+    /**
+     * Redirect the user to Google's OAuth consent screen.
+     */
+    public function redirect(GoogleCalendarService $gcal)
+    {
+        return redirect()->away($gcal->getAuthUrl());
+    }
+
+    /**
+     * Handle OAuth callback from Google.
+     */
+    public function callback(Request $request, GoogleCalendarService $gcal)
+    {
+        $code = $request->input('code');
+        if ($code) {
+            $gcal->handleCallback($code);
+        }
+
+        return redirect('/availability');
+    }
+}


### PR DESCRIPTION
## Summary
- add `GoogleController` under `Auth` namespace to manage OAuth redirects and callbacks

## Testing
- `composer install --ignore-platform-req=php`
- `php artisan key:generate --ansi`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880ea306838832f861ded6f940e5a71