### PR TITLE
Improve error handling for Google credentials

### DIFF
--- a/app/Http/Controllers/AvailabilityController.php
+++ b/app/Http/Controllers/AvailabilityController.php
@@ -10,6 +10,7 @@ class AvailabilityController extends Controller
 {
     public function index(Request $request, GoogleCalendarService $gcal)
     {
+        try {
         // 例：今週の月曜 9:00 ～ 金曜 18:00 を検索期間に
         $from = Carbon::now()->startOfWeek()->addHours(9);
         $to   = Carbon::now()->endOfWeek()->setHour(18);
@@ -57,5 +58,8 @@ class AvailabilityController extends Controller
         }
 
         return view('availability.index', compact('availabilities'));
+        } catch (\Throwable $e) {
+            return view('availability.error', ['message' => $e->getMessage()]);
+        }
     }
 }

--- a/app/Services/GoogleCalendarService.php
+++ b/app/Services/GoogleCalendarService.php
@@ -15,7 +15,11 @@ class GoogleCalendarService
     public function __construct()
     {
         $this->client = new Google_Client();
-        $this->client->setAuthConfig(config('google.client_credentials'));
+        $credPath = config('google.client_credentials');
+        if (!is_string($credPath) || !file_exists($credPath)) {
+            throw new \RuntimeException('Google credential file not found.');
+        }
+        $this->client->setAuthConfig($credPath);
         $this->client->setRedirectUri(config('google.redirect_uri'));
         $this->client->addScope(Google_Service_Calendar::CALENDAR_READONLY);
         $this->client->setAccessType('offline');

--- a/resources/views/availability/error.blade.php
+++ b/resources/views/availability/error.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>エラー</h1>
+<p>{{ \$message }}</p>
+@endsection


### PR DESCRIPTION
## Summary
- handle missing Google credentials in `GoogleCalendarService`
- catch errors in `AvailabilityController` and show friendly view
- add error blade view

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880ec072638832fb66e0875c5469584