### PR TITLE
Improve calendar availability flow and layout

### DIFF
--- a/app/Http/Controllers/Auth/GoogleController.php
+++ b/app/Http/Controllers/Auth/GoogleController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Services\GoogleCalendarService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class GoogleController extends Controller
+{
+    public function redirect(GoogleCalendarService $calendarService): RedirectResponse
+    {
+        return redirect()->away($calendarService->getAuthUrl());
+    }
+
+    public function callback(Request $request, GoogleCalendarService $calendarService): RedirectResponse
+    {
+        $code = $request->input('code');
+        abort_unless(is_string($code) && $code !== '', 400, 'Google 認可コードが取得できませんでした。');
+
+        $calendarService->handleCallback($code);
+
+        return redirect()->route('availability.index');
+    }
+}

--- a/app/Http/Controllers/AvailabilityController.php
+++ b/app/Http/Controllers/AvailabilityController.php
@@ -4,10 +4,13 @@ namespace App\Http\Controllers;
 
 use App\Services\GoogleCalendarService;
 use Carbon\Carbon;
+use Google_Service_Calendar_Event;
 use Illuminate\Http\Request;
 
 class AvailabilityController extends Controller
 {
+    private const BUSY_THRESHOLD = 4;
+
     public function index(Request $request, GoogleCalendarService $gcal)
     {
         // 例：今週の月曜 9:00 ～ 金曜 18:00 を検索期間に
@@ -24,35 +27,88 @@ class AvailabilityController extends Controller
 
         $events = $gcal->fetchEvents($calendarIds, $from, $to);
 
-        // Sweep-line アルゴリズムで重複数をカウント
         $points = [];
-        foreach ($events as $ev) {
-            $start = new Carbon($ev->getStart()->getDateTime() ?? $ev->getStart()->getDate());
-            $end   = new Carbon($ev->getEnd()->getDateTime() ?? $ev->getEnd()->getDate());
+        foreach ($events as $event) {
+            [$start, $end] = $this->resolveEventRange($event, $from, $to);
+            if (!$start || !$end || $start->gte($end)) {
+                continue;
+            }
+
             $points[] = ['time' => $start, 'delta' => +1];
             $points[] = ['time' => $end,   'delta' => -1];
         }
-        // 増分・減分でソート
-        usort($points, fn($a, $b) => $a['time']->lt($b['time']) ? -1 : 1);
+
+        usort($points, function (array $a, array $b): int {
+            $cmp = $a['time']->getTimestamp() <=> $b['time']->getTimestamp();
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+
+            return $a['delta'] <=> $b['delta'];
+        });
 
         $count = 0;
         $availabilities = [];
-        $windowStart = $from;
+        $windowStart = $from->copy();
 
         foreach ($points as $pt) {
             $now = $pt['time'];
-            // “4つ以上” に到達する前の空き区間を記録
-            if ($count < 4 && $now->gt($windowStart)) {
-                $availabilities[] = ['start' => $windowStart->copy(), 'end' => $now->copy()];
+            if ($count < self::BUSY_THRESHOLD && $now->gt($windowStart)) {
+                $this->pushAvailability($availabilities, $windowStart, $now);
             }
+
             $count += $pt['delta'];
-            $windowStart = $now;
+            $windowStart = $now->copy();
         }
-        // 最後に to まで空きがあれば
-        if ($count < 4 && $windowStart->lt($to)) {
-            $availabilities[] = ['start' => $windowStart, 'end' => $to];
+
+        if ($count < self::BUSY_THRESHOLD && $windowStart->lt($to)) {
+            $this->pushAvailability($availabilities, $windowStart, $to);
         }
 
         return view('availability.index', compact('availabilities'));
+    }
+
+    /**
+     * @return array{0: Carbon|null, 1: Carbon|null}
+     */
+    private function resolveEventRange(Google_Service_Calendar_Event $event, Carbon $from, Carbon $to): array
+    {
+        $start = $event->getStart()->getDateTime() ?? $event->getStart()->getDate();
+        $end = $event->getEnd()->getDateTime() ?? $event->getEnd()->getDate();
+
+        if (!$start || !$end) {
+            return [null, null];
+        }
+
+        $startAt = Carbon::parse($start);
+        $endAt = Carbon::parse($end);
+
+        if ($endAt->lte($from) || $startAt->gte($to)) {
+            return [null, null];
+        }
+
+        $startAt = $startAt->lt($from) ? $from->copy() : $startAt;
+        $endAt = $endAt->gt($to) ? $to->copy() : $endAt;
+
+        return [$startAt, $endAt];
+    }
+
+    private function pushAvailability(array &$availabilities, Carbon $start, Carbon $end): void
+    {
+        if ($start->gte($end)) {
+            return;
+        }
+
+        if (!empty($availabilities)) {
+            $lastIndex = array_key_last($availabilities);
+            $last = $availabilities[$lastIndex];
+
+            if ($last['end']->equalTo($start)) {
+                $availabilities[$lastIndex]['end'] = $end->copy();
+                return;
+            }
+        }
+
+        $availabilities[] = ['start' => $start->copy(), 'end' => $end->copy()];
     }
 }

--- a/app/Services/GoogleCalendarService.php
+++ b/app/Services/GoogleCalendarService.php
@@ -2,10 +2,11 @@
 
 namespace App\Services;
 
+use Carbon\Carbon;
 use Google_Client;
 use Google_Service_Calendar;
 use Google_Service_Calendar_Event;
-use Carbon\Carbon;
+use RuntimeException;
 
 class GoogleCalendarService
 {
@@ -17,7 +18,9 @@ class GoogleCalendarService
         $this->client = new Google_Client();
         $this->client->setAuthConfig(config('google.client_credentials'));
         $this->client->setRedirectUri(config('google.redirect_uri'));
-        $this->client->addScope(Google_Service_Calendar::CALENDAR_READONLY);
+        foreach (config('google.scopes', []) as $scope) {
+            $this->client->addScope($scope);
+        }
         $this->client->setAccessType('offline');
         $this->client->setPrompt('consent');
 
@@ -31,25 +34,39 @@ class GoogleCalendarService
     }
 
     /** OAuth コールバック後にトークンを保存 */
-    public function handleCallback(string $code)
+    public function handleCallback(string $code): void
     {
         $token = $this->client->fetchAccessTokenWithAuthCode($code);
+        if (isset($token['error'])) {
+            throw new RuntimeException('Google OAuth error: ' . $token['error']);
+        }
         session(['google_access_token' => $token]);
         $this->client->setAccessToken($token);
     }
 
     /** セッションのトークンをセット */
-    protected function ensureAccessToken()
+    protected function ensureAccessToken(): void
     {
         $token = session('google_access_token');
         if (!$token) {
-            throw new \Exception('Google トークンがありません。');
+            throw new RuntimeException('Google トークンがありません。');
         }
         $this->client->setAccessToken($token);
         // 必要ならリフレッシュ
         if ($this->client->isAccessTokenExpired()) {
-            $this->client->fetchAccessTokenWithRefreshToken($token['refresh_token']);
-            session(['google_access_token' => $this->client->getAccessToken()]);
+            $refreshToken = $token['refresh_token'] ?? null;
+            if (!$refreshToken) {
+                throw new RuntimeException('Google リフレッシュトークンがありません。');
+            }
+
+            $newToken = $this->client->fetchAccessTokenWithRefreshToken($refreshToken);
+            if (isset($newToken['error'])) {
+                throw new RuntimeException('Google トークンの更新に失敗しました: ' . $newToken['error']);
+            }
+
+            $token = array_merge($token, $newToken);
+            $this->client->setAccessToken($token);
+            session(['google_access_token' => $token]);
         }
     }
 
@@ -79,6 +96,13 @@ class GoogleCalendarService
 
             $allEvents = array_merge($allEvents, $events);
         }
+
+        usort($allEvents, function (Google_Service_Calendar_Event $a, Google_Service_Calendar_Event $b): int {
+            $startA = $a->getStart()->getDateTime() ?? $a->getStart()->getDate();
+            $startB = $b->getStart()->getDateTime() ?? $b->getStart()->getDate();
+
+            return strcmp($startA, $startB);
+        });
 
         return $allEvents;
     }

--- a/config/google.php
+++ b/config/google.php
@@ -1,4 +1,6 @@
 <?php
+
+use Google_Service_Calendar;
 return [
     // storage/credentials/client_secret.json への絶対パス
     'client_credentials' => env('GOOGLE_CLIENT_CREDENTIALS'),

--- a/resources/views/availability/index.blade.php
+++ b/resources/views/availability/index.blade.php
@@ -1,14 +1,24 @@
 @extends('layouts.app')
 
+@section('title', '空き時間帯ビューア')
+
 @section('content')
-<h1>空き時間帯（同時予定数＜4）</h1>
-<ul>
-    @foreach($availabilities as $slot)
-    <li>
-        {{ $slot['start']->format('Y/m/d H:i') }}
-        〜
-        {{ $slot['end']->format('Y/m/d H:i') }}
-    </li>
-    @endforeach
-</ul>
+    <p>下のリストは「同時予定数が4件未満」の時間帯を表示します。</p>
+    <p>
+        <a class="button" href="{{ route('google.auth') }}">Google カレンダーを連携</a>
+    </p>
+
+    @if (empty($availabilities))
+        <div class="empty-state">条件に合致する空き時間は見つかりませんでした。</div>
+    @else
+        <ul class="availabilities">
+            @foreach($availabilities as $slot)
+                <li>
+                    <span>{{ $slot['start']->format('Y/m/d H:i') }}</span>
+                    <span>〜</span>
+                    <span>{{ $slot['end']->format('Y/m/d H:i') }}</span>
+                </li>
+            @endforeach
+        </ul>
+    @endif
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', 'Calendar Checker')</title>
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=inter:400,500,600&display=swap" rel="stylesheet" />
+    <style>
+        body {
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            margin: 0;
+            background: #f5f5f5;
+            color: #1f2937;
+        }
+        header {
+            background: #1d4ed8;
+            color: #fff;
+            padding: 1.5rem 2rem;
+        }
+        main {
+            max-width: 960px;
+            margin: 2rem auto;
+            background: #fff;
+            padding: 2rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+        }
+        a.button {
+            display: inline-block;
+            padding: 0.75rem 1.5rem;
+            border-radius: 9999px;
+            background: #2563eb;
+            color: #fff;
+            font-weight: 600;
+            text-decoration: none;
+            transition: background-color 0.2s ease;
+        }
+        a.button:hover {
+            background: #1e3a8a;
+        }
+        ul.availabilities {
+            list-style: none;
+            padding: 0;
+            margin: 1.5rem 0 0;
+        }
+        ul.availabilities li {
+            padding: 1rem 1.25rem;
+            margin-bottom: 0.75rem;
+            border: 1px solid #e5e7eb;
+            border-radius: 0.75rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: #f9fafb;
+        }
+        ul.availabilities li span {
+            font-variant-numeric: tabular-nums;
+        }
+        .empty-state {
+            text-align: center;
+            padding: 2rem 1rem;
+            color: #6b7280;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>@yield('title', 'Calendar Checker')</h1>
+</header>
+<main>
+    @yield('content')
+</main>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,9 +13,13 @@ use Illuminate\Support\Facades\Route;
 |
 */
 // OAuth 認可
-Route::get('/oauth2callback', [App\Http\Controllers\Auth\GoogleController::class, 'callback']);
+Route::get('/google/auth', [App\Http\Controllers\Auth\GoogleController::class, 'redirect'])
+    ->name('google.auth');
+Route::get('/oauth2callback', [App\Http\Controllers\Auth\GoogleController::class, 'callback'])
+    ->name('google.callback');
 // 空き時間表示
-Route::get('/availability', [App\Http\Controllers\AvailabilityController::class, 'index']);
+Route::get('/availability', [App\Http\Controllers\AvailabilityController::class, 'index'])
+    ->name('availability.index');
 
 Route::get('/', function () {
     return view('welcome');


### PR DESCRIPTION
## Summary
- handle Google OAuth token errors and refreshes and sort merged Google Calendar events
- clamp event ranges when computing availability, merge contiguous free slots, and expose a threshold constant
- add a Google OAuth controller, named routes, and a basic layout plus refreshed availability view copy

## Testing
- composer test *(fails: Command "test" is not defined)*
- ./vendor/bin/phpunit *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dc92ebbd7c832faab431c713c4f8d6