### PR TITLE
Fix fallback availability when no calendar events

### DIFF
--- a/app/Http/Controllers/AvailabilityController.php
+++ b/app/Http/Controllers/AvailabilityController.php
@@ -76,26 +76,26 @@ class AvailabilityController extends Controller
             }
 
             if (empty($points)) {
-                $availabilities[] = ['start' => $from->copy(), 'end' => $to->copy()];
-            }
+                $availabilities = $this->buildFullAvailability($from, $to);
+            } else {
+                usort($points, fn($a, $b) => $a['time']->lt($b['time']) ? -1 : 1);
 
-            usort($points, fn($a, $b) => $a['time']->lt($b['time']) ? -1 : 1);
+                $count = 0;
+                $availabilities = [];
+                $windowStart = $from;
 
-            $count = 0;
-            $availabilities = [];
-            $windowStart = $from;
-
-            foreach ($points as $pt) {
-                $now = $pt['time'];
-                if ($count < 4 && $now->gt($windowStart)) {
-                    $availabilities[] = ['start' => $windowStart->copy(), 'end' => $now->copy()];
+                foreach ($points as $pt) {
+                    $now = $pt['time'];
+                    if ($count < 4 && $now->gt($windowStart)) {
+                        $availabilities[] = ['start' => $windowStart->copy(), 'end' => $now->copy()];
+                    }
+                    $count += $pt['delta'];
+                    $windowStart = $now;
                 }
-                $count += $pt['delta'];
-                $windowStart = $now;
-            }
 
-            if ($count < 4 && $windowStart->lt($to)) {
-                $availabilities[] = ['start' => $windowStart, 'end' => $to];
+                if ($count < 4 && $windowStart->lt($to)) {
+                    $availabilities[] = ['start' => $windowStart, 'end' => $to];
+                }
             }
             $availabilities = array_filter($availabilities, function ($slot) {
                 $start = $slot['start'];
@@ -162,5 +162,62 @@ class AvailabilityController extends Controller
         } catch (\Throwable $e) {
             return view('availability.error', ['message' => $e->getMessage()]);
         }
+    }
+
+    private function buildFullAvailability(Carbon $from, Carbon $to): array
+    {
+        $availabilities = [];
+        $currentDay = $from->copy()->startOfDay();
+
+        while ($currentDay->lte($to)) {
+            $dayOfWeek = $currentDay->dayOfWeekIso;
+
+            if (in_array($dayOfWeek, [1, 2])) {
+                $currentDay->addDay();
+                continue;
+            }
+
+            if (in_array($dayOfWeek, [6, 7])) {
+                $dayStart = $currentDay->copy()->setTime(10, 0);
+                $dayEnd = $currentDay->copy()->setTime(18, 30);
+            } else {
+                $dayStart = $currentDay->copy()->setTime(10, 0);
+                $dayEnd = $currentDay->copy()->setTime(20, 30);
+            }
+
+            $rangeStart = $dayStart;
+            $rangeEnd = $dayEnd;
+
+            if ($from->isSameDay($currentDay) && $from->gt($rangeStart)) {
+                $rangeStart = $from->copy();
+            }
+
+            if ($to->isSameDay($currentDay) && $to->lt($rangeEnd)) {
+                $rangeEnd = $to->copy();
+            }
+
+            if ($rangeStart->lt($rangeEnd)) {
+                $excludeStart = $currentDay->copy()->setTime(12, 0);
+                $excludeEnd = $currentDay->copy()->setTime(14, 0);
+
+                if ($rangeStart->lt($excludeStart)) {
+                    $morningEnd = $rangeEnd->lt($excludeStart) ? $rangeEnd->copy() : $excludeStart;
+                    if ($rangeStart->lt($morningEnd)) {
+                        $availabilities[] = ['start' => $rangeStart->copy(), 'end' => $morningEnd->copy()];
+                    }
+                }
+
+                if ($rangeEnd->gt($excludeEnd)) {
+                    $afternoonStart = $rangeStart->gt($excludeEnd) ? $rangeStart->copy() : $excludeEnd;
+                    if ($afternoonStart->lt($rangeEnd)) {
+                        $availabilities[] = ['start' => $afternoonStart->copy(), 'end' => $rangeEnd->copy()];
+                    }
+                }
+            }
+
+            $currentDay->addDay();
+        }
+
+        return $availabilities;
     }
 }

--- a/app/Http/Controllers/AvailabilityController.php
+++ b/app/Http/Controllers/AvailabilityController.php
@@ -86,14 +86,22 @@ class AvailabilityController extends Controller
                 foreach ($points as $pt) {
                     $now = $pt['time'];
                     if ($count < 4 && $now->gt($windowStart)) {
-                        $availabilities[] = ['start' => $windowStart->copy(), 'end' => $now->copy()];
+                        $availabilities[] = [
+                            'start' => $windowStart->copy(),
+                            'end'   => $now->copy(),
+                            'busy'  => $count,
+                        ];
                     }
                     $count += $pt['delta'];
                     $windowStart = $now;
                 }
 
                 if ($count < 4 && $windowStart->lt($to)) {
-                    $availabilities[] = ['start' => $windowStart, 'end' => $to];
+                    $availabilities[] = [
+                        'start' => $windowStart->copy(),
+                        'end'   => $to->copy(),
+                        'busy'  => $count,
+                    ];
                 }
             }
             $availabilities = array_filter($availabilities, function ($slot) {
@@ -143,14 +151,20 @@ class AvailabilityController extends Controller
                     continue;
                 }
 
-                $last = &$merged[count($merged) - 1];
+                $lastIndex = count($merged) - 1;
+                $last = &$merged[$lastIndex];
 
-                // 連続または隣接（例：18:00 → 18:30）していればマージ
-                if ($last['end']->equalTo($slot['start']) || $last['end']->diffInMinutes($slot['start']) <= 5) {
+                // 連続または隣接（例：18:00 → 18:30）しており、同じ混雑度ならマージ
+                if (
+                    $last['busy'] === $slot['busy'] &&
+                    ($last['end']->equalTo($slot['start']) || $last['end']->diffInMinutes($slot['start']) <= 5)
+                ) {
                     $last['end'] = $slot['end'];
                 } else {
                     $merged[] = $slot;
                 }
+
+                unset($last); // break reference
             }
 
             $availabilities = $merged;
@@ -202,14 +216,22 @@ class AvailabilityController extends Controller
                 if ($rangeStart->lt($excludeStart)) {
                     $morningEnd = $rangeEnd->lt($excludeStart) ? $rangeEnd->copy() : $excludeStart;
                     if ($rangeStart->lt($morningEnd)) {
-                        $availabilities[] = ['start' => $rangeStart->copy(), 'end' => $morningEnd->copy()];
+                        $availabilities[] = [
+                            'start' => $rangeStart->copy(),
+                            'end' => $morningEnd->copy(),
+                            'busy' => 0,
+                        ];
                     }
                 }
 
                 if ($rangeEnd->gt($excludeEnd)) {
                     $afternoonStart = $rangeStart->gt($excludeEnd) ? $rangeStart->copy() : $excludeEnd;
                     if ($afternoonStart->lt($rangeEnd)) {
-                        $availabilities[] = ['start' => $afternoonStart->copy(), 'end' => $rangeEnd->copy()];
+                        $availabilities[] = [
+                            'start' => $afternoonStart->copy(),
+                            'end' => $rangeEnd->copy(),
+                            'busy' => 0,
+                        ];
                     }
                 }
             }

--- a/app/Http/Controllers/AvailabilityController.php
+++ b/app/Http/Controllers/AvailabilityController.php
@@ -34,6 +34,12 @@ class AvailabilityController extends Controller
                 'c_62fdd6187530c4c29548c8a4e7ebf51cff6306f65b92da7da403a2009635e068@group.calendar.google.com',
             ];
 
+            $allowedConcurrentCaps = [5, 3, 1];
+            $maxConcurrent = (int) $request->input('max_concurrent', 5);
+            if (!in_array($maxConcurrent, $allowedConcurrentCaps, true)) {
+                $maxConcurrent = $allowedConcurrentCaps[0];
+            }
+
             $events = $gcal->fetchEvents($calendarIds, $from, $to);
 
             $calendarNames = [];
@@ -85,7 +91,7 @@ class AvailabilityController extends Controller
 
                 foreach ($points as $pt) {
                     $now = $pt['time'];
-                    if ($count < 4 && $now->gt($windowStart)) {
+                    if ($count < $maxConcurrent && $now->gt($windowStart)) {
                         $availabilities[] = [
                             'start' => $windowStart->copy(),
                             'end'   => $now->copy(),
@@ -96,7 +102,7 @@ class AvailabilityController extends Controller
                     $windowStart = $now;
                 }
 
-                if ($count < 4 && $windowStart->lt($to)) {
+                if ($count < $maxConcurrent && $windowStart->lt($to)) {
                     $availabilities[] = [
                         'start' => $windowStart->copy(),
                         'end'   => $to->copy(),
@@ -171,7 +177,12 @@ class AvailabilityController extends Controller
 
             $calendarNames = array_unique($calendarNames);
 
-            return view('availability.index', compact('availabilities', 'calendarNames'));
+            return view('availability.index', [
+                'availabilities' => $availabilities,
+                'calendarNames' => $calendarNames,
+                'maxConcurrent' => $maxConcurrent,
+                'allowedConcurrentCaps' => $allowedConcurrentCaps,
+            ]);
         } catch (\Throwable $e) {
             return view('availability.error', ['message' => $e->getMessage()]);
         }

--- a/app/Http/Controllers/AvailabilityController.php
+++ b/app/Http/Controllers/AvailabilityController.php
@@ -54,12 +54,11 @@ class AvailabilityController extends Controller
                 // 「どれだけ件数があっても 2 件として扱う」ロジック
                 $specialCalendarId = 'c_62fdd6187530c4c29548c8a4e7ebf51cff6306f65b92da7da403a2009635e068@group.calendar.google.com';
                 if ($calId === $specialCalendarId) {
-                    // 自身を連結 → 件数が1なら2件に、2件以上なら2件に、0件なら0件のまま
-                    $calendarEvents = array_slice(
-                        array_merge($calendarEvents, $calendarEvents),
-                        0,
-                        2
-                    );
+                    foreach ($this->mergeCalendarEvents($calendarEvents) as $range) {
+                        $points[] = ['time' => $range['start'], 'delta' => +2];
+                        $points[] = ['time' => $range['end'],   'delta' => -2];
+                    }
+                    continue;
                 }
 
                 foreach ($calendarEvents as $item) {
@@ -219,5 +218,55 @@ class AvailabilityController extends Controller
         }
 
         return $availabilities;
+    }
+
+    /**
+     * 特定カレンダーのイベントを結合して「常に最大2件」として扱うための時間帯配列を作成
+     *
+     * @param array $calendarEvents
+     * @return array<int, array{start: Carbon, end: Carbon}>
+     */
+    private function mergeCalendarEvents(array $calendarEvents): array
+    {
+        $intervals = [];
+
+        foreach ($calendarEvents as $item) {
+            $event = $item['event'];
+            $start = new Carbon($event->getStart()->getDateTime() ?? $event->getStart()->getDate());
+            $end = new Carbon($event->getEnd()->getDateTime() ?? $event->getEnd()->getDate());
+
+            if ($end->lte($start) || in_array($start->dayOfWeekIso, [1, 2])) {
+                continue;
+            }
+
+            $intervals[] = ['start' => $start, 'end' => $end];
+        }
+
+        if (empty($intervals)) {
+            return [];
+        }
+
+        usort($intervals, fn ($a, $b) => $a['start']->lt($b['start']) ? -1 : 1);
+
+        $merged = [$intervals[0]];
+
+        foreach (array_slice($intervals, 1) as $interval) {
+            $lastIndex = count($merged) - 1;
+            $last = $merged[$lastIndex];
+
+            if ($interval['start']->lte($last['end'])) {
+                if ($interval['end']->gt($last['end'])) {
+                    $merged[$lastIndex]['end'] = $interval['end'];
+                }
+                continue;
+            }
+
+            $merged[] = $interval;
+        }
+
+        return array_map(fn ($range) => [
+            'start' => $range['start']->copy(),
+            'end' => $range['end']->copy(),
+        ], $merged);
     }
 }

--- a/resources/views/availability/index.blade.php
+++ b/resources/views/availability/index.blade.php
@@ -1,7 +1,24 @@
 @extends('layouts.app')
 
 @section('content')
-<h1>空き時間帯（同時予定数＜4）</h1>
+<h1>空き時間帯（同時予定数＜{{ $maxConcurrent }}）</h1>
+
+<div class="mb-3">
+    <span>表示切り替え：</span>
+    @foreach ($allowedConcurrentCaps as $cap)
+        @php
+            $isActive = $cap === $maxConcurrent;
+            $query = array_merge(request()->query(), ['max_concurrent' => $cap]);
+        @endphp
+        <a
+            href="{{ route('availability.index', $query) }}"
+            class="btn {{ $isActive ? 'btn-primary' : 'btn-outline-primary' }}"
+            style="margin-right: 0.5rem;"
+        >
+            {{ sprintf('同時予定数＜%d', $cap) }}
+        </a>
+    @endforeach
+</div>
 
 <h2>使用カレンダー</h2>
 <ul>
@@ -19,7 +36,7 @@ $weekdays = ['日', '月', '火', '水', '木', '金', '土'];
 $wday = $weekdays[$slot['start']->dayOfWeek]; // 0〜6
 $dateLabel = $slot['start']->format('n月j日') . "（{$wday}）";
 $busyCount = $slot['busy'] ?? 0;
-$availableSlots = max(0, 4 - $busyCount);
+$availableSlots = max(0, $maxConcurrent - $busyCount);
 $timeRange = sprintf(
     '%s~%s（予定%d件／残り%d枠）',
     $slot['start']->format('H:i'),
@@ -35,7 +52,7 @@ $slotsByDate[$dateLabel][] = $timeRange;
 <h2>空き時間一覧</h2>
 <ul>
     @foreach ($slotsByDate as $dateLabel => $times)
-    <li>{{ $dateLabel }}：{{ implode('、', $times) }}</li>
+        <li>{{ $dateLabel }}：{{ implode('、', $times) }}</li>
     @endforeach
 </ul>
 @endsection

--- a/resources/views/availability/index.blade.php
+++ b/resources/views/availability/index.blade.php
@@ -18,7 +18,15 @@ foreach ($availabilities as $slot) {
 $weekdays = ['日', '月', '火', '水', '木', '金', '土'];
 $wday = $weekdays[$slot['start']->dayOfWeek]; // 0〜6
 $dateLabel = $slot['start']->format('n月j日') . "（{$wday}）";
-$timeRange = $slot['start']->format('H:i') . '~' . $slot['end']->format('H:i');
+$busyCount = $slot['busy'] ?? 0;
+$availableSlots = max(0, 4 - $busyCount);
+$timeRange = sprintf(
+    '%s~%s（予定%d件／残り%d枠）',
+    $slot['start']->format('H:i'),
+    $slot['end']->format('H:i'),
+    $busyCount,
+    $availableSlots
+);
 $slotsByDate[$dateLabel][] = $timeRange;
 }
 @endphp

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,7 @@ Route::get('/auth/google/callback', function (\Illuminate\Http\Request $request,
     }
 })->name('google.callback');
 // 空き時間表示
-Route::get('/availability', [AvailabilityController::class, 'index']);
+Route::get('/availability', [AvailabilityController::class, 'index'])->name('availability.index');
 
 Route::get('/', function () {
     return view('welcome');


### PR DESCRIPTION
## Summary
- avoid clearing the default all-day slot when no calendar events exist
- split the fallback availability into per-day windows that respect opening hours and the midday break

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dc95d6d528832f9c9ec8df0e7e6f24